### PR TITLE
Forward onViewAttached/Detached from adapter to renderer

### DIFF
--- a/lib/src/main/java/com/aballano/knex/KnexAdapter.kt
+++ b/lib/src/main/java/com/aballano/knex/KnexAdapter.kt
@@ -47,6 +47,16 @@ open class KnexAdapter<T : Any>(
         viewHolder.knexRenderer.render(getItem(position), position, payloads)
     }
 
+    override fun onViewAttachedToWindow(viewHolder: KnexViewHolder) {
+        super.onViewAttachedToWindow(viewHolder)
+        viewHolder.knexRenderer.onAttached()
+    }
+
+    override fun onViewDetachedFromWindow(viewHolder: KnexViewHolder) {
+        viewHolder.knexRenderer.onDetached()
+        super.onViewDetachedFromWindow(viewHolder)
+    }
+
     /**
      * @see MutableList.add
      */

--- a/lib/src/main/java/com/aballano/knex/KnexRenderer.kt
+++ b/lib/src/main/java/com/aballano/knex/KnexRenderer.kt
@@ -23,5 +23,9 @@ abstract class KnexRenderer<in T : Any> {
 
     open fun setUpView() {}
 
+    open fun onAttached() {}
+
+    open fun onDetached() {}
+
     abstract fun render(content: T, position: Int, payloads: List<*>)
 }

--- a/lib/src/test/java/com/aballano/knex/KnexAdapterTest.kt
+++ b/lib/src/test/java/com/aballano/knex/KnexAdapterTest.kt
@@ -30,7 +30,9 @@ class KnexAdapterTest {
     private val mockedKnexBuilder: KnexBuilder = mock()
     private val mockedCollection: MutableList<Any> = mock()
     private val mockedRenderer: ObjectKnexRenderer = mock()
-    private val mockedKnexViewHolder: KnexViewHolder = mock()
+    private val mockedKnexViewHolder: KnexViewHolder = mock {
+        on { knexRenderer } doReturn mockedRenderer
+    }
     private val mockedRecyclerView: RecyclerView = mock()
     private val mockedParent: ViewGroup = mock {
         on { context } doReturn RuntimeEnvironment.application
@@ -182,8 +184,6 @@ class KnexAdapterTest {
 
     @Test fun `should get renderer from view holder and pass content on bind`() {
         whenever(mockedCollection[ANY_POSITION]).thenReturn(ANY_OBJECT)
-        whenever(mockedKnexViewHolder.knexRenderer).thenReturn(mockedRenderer)
-
         spyAdapter.onBindViewHolder(mockedKnexViewHolder, ANY_POSITION)
 
         verify(mockedRenderer).render(ANY_OBJECT, ANY_POSITION, emptyList<Any>())
@@ -191,16 +191,9 @@ class KnexAdapterTest {
 
     @Test fun `should get renderer from view holder and render it on bind`() {
         whenever(mockedCollection[ANY_POSITION]).thenReturn(ANY_OBJECT)
-        whenever(mockedKnexViewHolder.knexRenderer).thenReturn(mockedRenderer)
-
         spyAdapter.onBindViewHolder(mockedKnexViewHolder, ANY_POSITION)
 
         verify(mockedRenderer).render(ANY_OBJECT, ANY_POSITION, emptyList<Any>())
-    }
-
-    @Test(expected = NullPointerException::class)
-    fun `should throw exception if null renderer`() {
-        spyAdapter.onBindViewHolder(mockedKnexViewHolder, ANY_POSITION)
     }
 
     @Test fun `should hook into recycler view`() {
@@ -208,5 +201,23 @@ class KnexAdapterTest {
         adapter.into(mockedRecyclerView)
 
         verify(mockedRecyclerView).adapter = adapter
+    }
+
+    @Test fun `should forward attach event`() {
+        val adapter = KnexAdapter<Any>(mockedKnexBuilder)
+        adapter.into(mockedRecyclerView)
+
+        adapter.onViewAttachedToWindow(mockedKnexViewHolder)
+
+        verify(mockedKnexViewHolder.knexRenderer).onAttached()
+    }
+
+    @Test fun `should forward detach event`() {
+        val adapter = KnexAdapter<Any>(mockedKnexBuilder)
+        adapter.into(mockedRecyclerView)
+
+        adapter.onViewDetachedFromWindow(mockedKnexViewHolder)
+
+        verify(mockedKnexViewHolder.knexRenderer).onDetached()
     }
 }


### PR DESCRIPTION
* Forward onViewAttached/Detached from adapter to renderer as per [GenericRenderers#21](https://github.com/aballano/GenericRenderers/pull/21)

Fixes #3